### PR TITLE
Fix mismatch in preg_match when matching config like '*/vendor_general/enabled'

### DIFF
--- a/Cron/Sections.php
+++ b/Cron/Sections.php
@@ -54,7 +54,7 @@ class Sections
     {
         $connection = $this->resource->getConnection();
         $table = $this->resource->getTableName('core_config_data');
-        $path = strrev('delbane/lareneg');
+        $path = strrev('delbane/lareneg/');
 
         $select = $connection->select()->from(
             [$table]


### PR DESCRIPTION
The following error occurs when matching config on enabled module
Notice: Undefined offset: 1 in /data/web/magento2/magento/vendor/magefan/module-community/Cron/Sections.php on line 76

Config path example resulting in mismatch is 'payment/mollie_general/enabled'.
You can use this for testing. 

As I don't know if there are any of your modules containing config paths like */vendor_general/enabled you can better check first.