### PR TITLE
Removed reversed URL

### DIFF
--- a/Block/Adminhtml/System/Config/Form/ProductKeyField.php
+++ b/Block/Adminhtml/System/Config/Form/ProductKeyField.php
@@ -16,6 +16,8 @@ use Magento\Framework\App\ObjectManager;
  */
 class ProductKeyField extends Field
 {
+    const ACCOUNT_URL = 'https://magefan.com/downloadable/customer/products/';
+
     /**
      * Retrieve HTML markup for given form element
      *
@@ -31,8 +33,7 @@ class ProductKeyField extends Field
         $section = ObjectManager::getInstance()->create(Section::class, ['name' => $path]);
         if ($section->getModule()) {
             if (!$element->getComment()) {
-                $url = strrev('/stcudorp/remotsuc/elbadaolnwod/moc.nafegam//:sptth');
-                $element->setComment('You can find product key in your <a href="' . $url . '" target="_blank">Magefan account</a>.');
+                $element->setComment('You can find product key in your <a href="' . self::ACCOUNT_URL . '" target="_blank">Magefan account</a>.');
             }
             return parent::render($element);
         } else {


### PR DESCRIPTION
# Summary
I have removed a reversed URL in the source code. This is flagging up as potential malware on the scans we run across our clients infrastructure, I imagine others may be having this issue too so I made a slight alteration so that it would not flag up.

Having the URL reversed does not seem to serve any purpose so I have placed it in a class const.

If you find this PR useful and accept it, and its not too much hassle would you be able to add the `hacktoberfest-accepted` label so it counts toward my total 🙂 .